### PR TITLE
Fixing two-way binding with MRL grid.

### DIFF
--- a/src/igniteui.angular2.ts
+++ b/src/igniteui.angular2.ts
@@ -522,7 +522,7 @@ export class IgGridBase<Model> extends IgControlBase<Model> implements AfterCont
 				for (i = 0; i < diff.length; i++) {
 					for (j = 0; j < diff[i].txlog.length; j++) {
 						record = this._config.dataSource[diff[i].index];
-						td = element.data(this._widgetName)._getCellsByColKey(element.find("tr[data-id='" + record[pkKey] + "']"), diff[i].txlog[j].key);
+						td = grid._getCellsByColKey(element.find("tr[data-id='" + record[pkKey] + "']"), diff[i].txlog[j].key);
 
 						column = element.data(this._widgetName).columnByKey(diff[i].txlog[j].key);
 						if (column) {

--- a/src/igniteui.angular2.ts
+++ b/src/igniteui.angular2.ts
@@ -502,7 +502,7 @@ export class IgGridBase<Model> extends IgControlBase<Model> implements AfterCont
 			var diff = [],
 				element = jQuery(this._el),
 				grid = element.data(this._widgetName),
-				colIndex, td, i, j, pkKey = this._config.primaryKey, newFormattedVal, record, column;
+				td, i, j, pkKey = this._config.primaryKey, newFormattedVal, record, column;
 
 			if (typeof this._config.dataSource === "string") {
 				return;
@@ -521,9 +521,8 @@ export class IgGridBase<Model> extends IgControlBase<Model> implements AfterCont
 				this._dataSource = jQuery.extend(true, [], this._config.dataSource);
 				for (i = 0; i < diff.length; i++) {
 					for (j = 0; j < diff[i].txlog.length; j++) {
-						colIndex = element.data(this._widgetName)._getCellIndexByColumnKey(diff[i].txlog[j].key);
 						record = this._config.dataSource[diff[i].index];
-						td = element.find("tr[data-id='" + record[pkKey] + "']").children().get(colIndex);
+						td = element.data(this._widgetName)._getCellsByColKey(element.find("tr[data-id='" + record[pkKey] + "']"), diff[i].txlog[j].key);
 
 						column = element.data(this._widgetName).columnByKey(diff[i].txlog[j].key);
 						if (column) {

--- a/src/igniteui.angular2.ts
+++ b/src/igniteui.angular2.ts
@@ -524,7 +524,7 @@ export class IgGridBase<Model> extends IgControlBase<Model> implements AfterCont
 						record = this._config.dataSource[diff[i].index];
 						td = grid._getCellsByColKey(element.find("tr[data-id='" + record[pkKey] + "']"), diff[i].txlog[j].key);
 
-						column = element.data(this._widgetName).columnByKey(diff[i].txlog[j].key);
+						column = grid.columnByKey(diff[i].txlog[j].key);
 						if (column) {
 							if (column.template) {
 								newFormattedVal = grid._renderTemplatedCell(diff[i].txlog[j].newVal, column);


### PR DESCRIPTION
Related to bug #233454: Two-way data binding of igniteui-angular2 extension updates wrong cell's value when the grid is configuring with multi row layout.