### PR TITLE
Additional fix for bug 233254.

### DIFF
--- a/src/igniteui.angular2.ts
+++ b/src/igniteui.angular2.ts
@@ -1499,6 +1499,10 @@ export class IgGridBase<Model> extends IgControlBase<Model> implements AfterCont
 							} else {
 								newFormattedVal = grid._renderCell(diff[i].txlog[j].newVal, column, record);
 							}
+							//if current cell is still in edit mode, exit it.
+							if (jQuery(td).find("input.ui-igedit-input").length > 0){
+								element.data("igGridUpdating").endEdit();
+							}
 							jQuery(td).html(newFormattedVal);
 							grid.dataSource.updateRow(record[pkKey], record);
 							grid.dataSource._commitTransactionsByRowId(record[pkKey]);


### PR DESCRIPTION
Making sure that grid is not in edit mode while the data is updated. 
This can happen in some specific cases when Updating is enabled, there is only 1 record in the grid and
you enter edit mode for it, edit it and hit Enter then the cell will exit edit mode, triggering a change in the data source, and then immediately enter edit mode again for the same cell because Enter triggers keyboard navigation to the next row (which is the same row in this scenario) and enters edit mode for the next cell. 
Due to this an additional check should be added to see if the cell is in edit mode while the data is updated.